### PR TITLE
Fix for ribotie issue #11

### DIFF
--- a/transcript_transformer/argparser.py
+++ b/transcript_transformer/argparser.py
@@ -499,7 +499,25 @@ class Parser(argparse.ArgumentParser):
         # ribo takes precedence over ribo_paths
         if args.use_ribo:
             if (args.samples is not None) and (len(args.samples) > 0):
-                args.ribo_ids = [r if type(r) == list else [r] for r in args.samples]
+                if isinstance(args.samples, list):
+                    args.ribo_ids = [r if type(r) == list else [r] for r in args.samples]
+                elif isinstance(args.samples, dict):
+                    args.ribo_study_ids=[]
+                    args.ribo_ids=[]
+                    for key, value in args.samples.items():
+                        #in case where args.sample is given as a dict makes sure 
+                        assert (
+                            isinstance(value, str) or 
+                            (isinstance(value, list) and all(isinstance(x, str) for x in value))
+                        ), (
+                            "Sample when given a study id should be a string or file id or list of str of file id, "
+                            "recheck your yaml to make sure it fits the documentation"
+                        )
+                        args.ribo_study_ids.append(key)
+                        if isinstance(value, str):
+                            args.ribo_ids.append([value])
+                        else:
+                            args.ribo_ids.append(value)
             else:
                 args.ribo_ids = [[r] for r in args.ribo_paths.keys()]
             flat_ids = sum(args.ribo_ids, [])

--- a/transcript_transformer/ribotie.py
+++ b/transcript_transformer/ribotie.py
@@ -187,7 +187,10 @@ def main():
             args_set = deepcopy(args)
             args_set.ribo_ids = [ribo_set]
             args_set.cond["grouped"] = [args.cond["grouped"][i]]
-            ribo_set_str = "&".join(ribo_set)
+            if (args.ribo_study_ids is not None):
+                ribo_set_str = args.ribo_study_ids[i]
+            else:
+                ribo_set_str = "&".join(ribo_set)
             for j, fold in args_set.pretrained_model["folds"].items():
                 args_set.__dict__.update(fold)
                 args_set.transfer_checkpoint = os.path.join(
@@ -201,8 +204,11 @@ def main():
                 print(f"--> Predicting samples for {ribo_set_str}...")
                 args_set.out_prefix = f"{args.out_prefix}{ribo_set_str}_f{j}"
                 predict(args_set, trainer=trainer, model=model, postprocess=False)
-
-            ribo_set_str = "&".join(ribo_set)
+            #idk why this line is duplicated after fold training but I modified both as to not break things
+            if (args.ribo_study_ids is not None):
+                ribo_set_str = args.ribo_study_ids[i]
+            else:
+                ribo_set_str = "&".join(ribo_set)
             prefix = f"{args.out_prefix}{ribo_set_str}"
             merge_outputs(prefix, args.pretrained_model["folds"].keys())
 
@@ -210,7 +216,10 @@ def main():
         if args.pretrain:
             args.ribo_ids = [[f"pretrain_f{i}"] for i, fold in args.folds.items()]
         for ribo_set in args.ribo_ids:
-            ribo_set_str = "&".join(ribo_set)
+            if (args.ribo_study_ids is not None):
+                ribo_set_str = args.ribo_study_ids[i]
+            else:
+                ribo_set_str = "&".join(ribo_set)
             out = np.load(f"{args.out_prefix}{ribo_set_str}.npy", allow_pickle=True)
             out_prefix = f"{args.out_prefix}{ribo_set_str}"
             df = construct_output_table(


### PR DESCRIPTION
Hi,
I have added here the possibility to give 'sample:' in the yaml a dict of list.
The idea is to give the list of studies a name that can be used to save files with and it is given as the key
ex GSE_cyclo_HELA
and in the list give the list of of the files given

the yaml would look like this

<details>
<summary> click to expand yml exemple </summary>
`
gtf_path: /path/Homo_sapiens.GRCh38.113.gtf
fa_path: /path/Homo_sapiens.GRCh38.dna.primary_assembly.fa

ribo_paths:
  GSM5527690: /path/GSE182377_cycloheximide_Fibroblast/GSM5527690/GSM5527690_Aligned.toTranscriptome.out.bam
  GSM5527691: /path/GSE182377_cycloheximide_Fibroblast/GSM5527691/GSM5527691_Aligned.toTranscriptome.out.bam
  GSM5527692: /path/GSE182377_cycloheximide_Fibroblast/GSM5527692/GSM5527692_Aligned.toTranscriptome.out.bam
  GSM5527693: /path/GSE182377_cycloheximide_Fibroblast/GSM5527693/GSM5527693_Aligned.toTranscriptome.out.bam
  GSM5527694: /path/GSE182377_cycloheximide_Fibroblast/GSM5527694/GSM5527694_Aligned.toTranscriptome.out.bam
  GSM5527695: /path/GSE182377_cycloheximide_Fibroblast/GSM5527695/GSM5527695_Aligned.toTranscriptome.out.bam
  GSM5527696: /path/GSE182377_cycloheximide_Fibroblast/GSM5527696/GSM5527696_Aligned.toTranscriptome.out.bam
  GSM5527697: /path/GSE182377_cycloheximide_Fibroblast/GSM5527697/GSM5527697_Aligned.toTranscriptome.out.bam
  GSM5527698: /path/GSE182377_cycloheximide_Fibroblast/GSM5527698/GSM5527698_Aligned.toTranscriptome.out.bam
  GSM5527699: /path/GSE182377_cycloheximide_Fibroblast/GSM5527699/GSM5527699_Aligned.toTranscriptome.out.bam
  GSM5527700: /path/GSE182377_cycloheximide_Fibroblast/GSM5527700/GSM5527700_Aligned.toTranscriptome.out.bam
  GSM5527701: /path/GSE182377_cycloheximide_Fibroblast/GSM5527701/GSM5527701_Aligned.toTranscriptome.out.bam
  GSM5527702: /path/GSE182377_cycloheximide_Fibroblast/GSM5527702/GSM5527702_Aligned.toTranscriptome.out.bam
  GSM5527703: /path/GSE182377_cycloheximide_Fibroblast/GSM5527703/GSM5527703_Aligned.toTranscriptome.out.bam
  GSM5527704: /path/GSE182377_cycloheximide_Fibroblast/GSM5527704/GSM5527704_Aligned.toTranscriptome.out.bam

samples:
  GSE182377: 
    - GSM5527690
    - GSM5527691
    - GSM5527692
    - GSM5527693
    - GSM5527694
    - GSM5527695
    - GSM5527696
    - GSM5527697
    - GSM5527698
    - GSM5527699
    - GSM5527700
    - GSM5527701
    - GSM5527702
    - GSM5527703
    - GSM5527704

h5_path: /path/data/GSE182377_fibroblast.h5
out_dir: /path/data/results_GSE182377
 `
</details>

To give a rundown of the code i changed,
I added a check in the argparser to check if sample: content is a dictionnary
If it is, i created a new arg i would use as the new file name instead of stackking all GSM names
I then went back to every part of the code that specified the save string and check if the  new argument i created exists, if it does i use it to name the file, else what you code did before

As it is you code and I don't have formal computer science training, the variable names might not be descriptive enough. 
My modification should work and while testing them I run into an error that i described in issue #13. 
The issue doesnt seem to come from what I modified because I run into the same issue when using the untouched repo.
Since it block there, i wasn't able to confirm whether everything that i changed works 100%
I can wait for the other bug to be fixed before retesting this PR to confirm

Also, I am wondering when a new official release is coming, id like to run the version of ribotie with the updated ORF_type names in the output_table construction

Cheers

Nicolas