### PR TITLE
Fix torch.load not allowing checkpoint loading when for checkpoints that include functions.

### DIFF
--- a/transcript_transformer/models.py
+++ b/transcript_transformer/models.py
@@ -4,6 +4,9 @@ import pytorch_lightning as pl
 import torchmetrics as tm
 from performer_pytorch import Performer
 from performer_pytorch.performer_pytorch import FixedPositionalEmbedding
+from torch.nn.modules.activation import ReLU
+
+torch.serialization.add_safe_globals([ReLU])
 
 
 class TranscriptSeqRiboEmb(pl.LightningModule):


### PR DESCRIPTION
- Fix torch.load security issue for torch >= 2.6 (#19)